### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/src/pycalendar/__init__.py
+++ b/src/pycalendar/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 #    Copyright (c) 2007-2015 Cyrus Daboo. All rights reserved.
 #
@@ -16,38 +17,38 @@
 
 # Import these to register the values
 
-import binaryvalue
-import caladdressvalue
-import datetimevalue
-import durationvalue
-import floatvalue
-import geovalue
-import icalendar.recurrencevalue
-import icalendar.requeststatusvalue
-import integervalue
-import multivalue
-import periodvalue
-import textvalue
-import unknownvalue
-import urivalue
-import utcoffsetvalue
-import vcard.adrvalue
-import vcard.nvalue
-import vcard.orgvalue
+from . import binaryvalue
+from . import caladdressvalue
+from . import datetimevalue
+from . import durationvalue
+from . import floatvalue
+from . import geovalue
+from .icalendar import recurrencevalue
+from .icalendar import requeststatusvalue
+from . import integervalue
+from . import multivalue
+from . import periodvalue
+from . import textvalue
+from . import unknownvalue
+from . import urivalue
+from . import utcoffsetvalue
+from .vcard import adrvalue
+from .vcard import nvalue
+from .vcard import orgvalue
 
 # Import these to register the components
 
-import icalendar.available
-import icalendar.valarm
-import icalendar.vavailability
-import icalendar.vevent
-import icalendar.vfreebusy
-import icalendar.vjournal
-import icalendar.vpoll
-import icalendar.vote
-import icalendar.vtimezone
-import icalendar.vtimezonedaylight
-import icalendar.vtimezonestandard
-import icalendar.vtodo
-import icalendar.vunknown
-import icalendar.vvoter
+from .icalendar import available
+from .icalendar import valarm
+from .icalendar import vavailability
+from .icalendar import vevent
+from .icalendar import vfreebusy
+from .icalendar import vjournal
+from .icalendar import vpoll
+from .icalendar import vote
+from .icalendar import vtimezone
+from .icalendar import vtimezonedaylight
+from .icalendar import vtimezonestandard
+from .icalendar import vtodo
+from .icalendar import vunknown
+from .icalendar import vvoter

--- a/src/pycalendar/datetime.py
+++ b/src/pycalendar/datetime.py
@@ -25,6 +25,12 @@ import cStringIO as StringIO
 import time
 import xml.etree.cElementTree as XML
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
+
 
 class DateTime(ValueMixin):
 
@@ -226,13 +232,13 @@ class DateTime(ValueMixin):
         # Look for cached value (or floating time which has to be calculated
         # each time)
         if (not self.mPosixTimeCached) or self.floating():
-            result = 0L
+            result = 0
 
             # Add hour/mins/secs
-            result = (self.mHours * 60L + self.mMinutes) * 60L + self.mSeconds
+            result = (self.mHours * 60 + self.mMinutes) * 60 + self.mSeconds
 
             # Number of days since 1970
-            result += self.daysSince1970() * 24L * 60L * 60L
+            result += self.daysSince1970() * 24 * 60 * 60
 
             # Adjust for timezone offset
             result -= self.timeZoneSecondsOffset()

--- a/src/pycalendar/icalendar/calendar.py
+++ b/src/pycalendar/icalendar/calendar.py
@@ -533,9 +533,9 @@ class Calendar(ContainerBase):
         # Create non-overlapping periods as properties in the freebusy component
         temp = Period(dtstart.front(), dtend.front())
         dtstart_iter = dtstart.iter()
-        dtstart_iter.next()
+        next(dtstart_iter)
         dtend_iter = dtend.iter()
-        dtend_iter.next()
+        next(dtend_iter)
         for _ignore in (None,):
 
             # Check for non-overlap

--- a/src/pycalendar/icalendar/property.py
+++ b/src/pycalendar/icalendar/property.py
@@ -30,6 +30,11 @@ from pycalendar.property import PropertyBase
 from pycalendar.utcoffsetvalue import UTCOffsetValue
 from pycalendar.value import Value
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class Property(PropertyBase):
 

--- a/src/pycalendar/icalendar/recurrence.py
+++ b/src/pycalendar/icalendar/recurrence.py
@@ -23,6 +23,11 @@ from pycalendar.valueutils import ValueMixin
 import cStringIO as StringIO
 import xml.etree.cElementTree as XML
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 def WeekDayNumCompare_compare(w1, w2):
 

--- a/src/pycalendar/parameter.py
+++ b/src/pycalendar/parameter.py
@@ -24,6 +24,11 @@ from pycalendar import xmldefinitions, xmlutils
 from pycalendar.utils import encodeParameterValue
 import xml.etree.cElementTree as XML
 
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 
 class Parameter(object):
 

--- a/src/pycalendar/utils.py
+++ b/src/pycalendar/utils.py
@@ -17,6 +17,11 @@
 from pycalendar.parser import ParserContext
 import cStringIO as StringIO
 
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 
 def readFoldedLine(ins, lines):
 

--- a/src/pycalendar/validator.py
+++ b/src/pycalendar/validator.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 ##
 
+from __future__ import print_function
 from pycalendar.icalendar.calendar import Calendar
 from pycalendar.exceptions import ErrorBase
 from pycalendar.parser import ParserContext

--- a/src/pycalendar/vcard/n.py
+++ b/src/pycalendar/vcard/n.py
@@ -19,6 +19,11 @@
 from pycalendar import utils
 from pycalendar.valueutils import ValueMixin
 
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 
 class N(ValueMixin):
     """

--- a/src/zonal/rule.py
+++ b/src/zonal/rule.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 #    Copyright (c) 2007-2013 Cyrus Daboo. All rights reserved.
 #
@@ -22,7 +23,12 @@ from pycalendar.icalendar.vtimezonedaylight import Daylight
 from pycalendar.icalendar.vtimezonestandard import Standard
 from pycalendar.utcoffsetvalue import UTCOffsetValue
 from pycalendar.utils import daysInMonth
-import utils
+from . import utils
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 """
 Class that maintains a TZ data Rule.

--- a/src/zonal/tzconvert.py
+++ b/src/zonal/tzconvert.py
@@ -17,18 +17,19 @@
 
 from __future__ import with_statement
 from __future__ import print_function
+from __future__ import absolute_import
 
 from pycalendar.icalendar.calendar import Calendar
 from xml.etree.cElementTree import ParseError as XMLParseError
 import cStringIO as StringIO
 import getopt
 import os
-import rule
+from . import rule
 import sys
 import tarfile
 import urllib
 import xml.etree.cElementTree as XML
-import zone
+from . import zone
 
 """
 Classes to parse a tzdata files and generate VTIMEZONE data.

--- a/src/zonal/tzdump.py
+++ b/src/zonal/tzdump.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 ##
 
+from __future__ import print_function
 from pycalendar.datetime import DateTime
 from pycalendar.exceptions import InvalidData
 from pycalendar.icalendar.calendar import Calendar
@@ -27,12 +28,12 @@ def loadCalendar(file, verbose):
 
     cal = Calendar()
     if verbose:
-        print "Parsing calendar data: %s" % (file,)
+        print("Parsing calendar data: %s" % (file,))
     with open(file, "r") as fin:
         try:
             cal.parse(fin)
-        except InvalidData, e:
-            print "Failed to parse bad data: %s" % (e.mData,)
+        except InvalidData as e:
+            print("Failed to parse bad data: %s" % (e.mData,))
             raise
     return cal
 
@@ -73,9 +74,9 @@ def secondsToTime(seconds):
 
 def usage(error_msg=None):
     if error_msg:
-        print error_msg
+        print(error_msg)
 
-    print """Usage: tzdump [options] FILE
+    print("""Usage: tzdump [options] FILE
 Options:
     -h            Print this help and exit
     -v            Be verbose
@@ -89,7 +90,7 @@ Description:
     This utility will dump the transitions in a VTIMEZONE over
     the request time range.
 
-"""
+""")
 
     if error_msg:
         raise ValueError(error_msg)
@@ -128,4 +129,4 @@ if __name__ == '__main__':
 
     cal = loadCalendar(fpath, verbose)
     dates = getExpandedDates(cal, start, end)
-    print formattedExpandedDates(dates)
+    print(formattedExpandedDates(dates))

--- a/src/zonal/tzverify.py
+++ b/src/zonal/tzverify.py
@@ -15,10 +15,12 @@
 #    limitations under the License.
 ##
 
+from __future__ import print_function
+from __future__ import absolute_import
 from pycalendar.datetime import DateTime
 from pycalendar.exceptions import InvalidData
 from pycalendar.icalendar.calendar import Calendar
-from tzconvert import tzconvert
+from .tzconvert import tzconvert
 import getopt
 import os
 import sys
@@ -28,7 +30,7 @@ from pycalendar.icalendar import definitions
 def loadCalendarFromZoneinfo(zoneinfopath, skips=(), only=(), verbose=False, quiet=False):
 
     if not quiet:
-        print "Scanning for calendar data in: %s" % (zoneinfopath,)
+        print("Scanning for calendar data in: %s" % (zoneinfopath,))
     paths = []
 
     def scanForICS(dirpath):
@@ -41,7 +43,7 @@ def loadCalendarFromZoneinfo(zoneinfopath, skips=(), only=(), verbose=False, qui
                     for item in only:
                         if item in fpath:
                             if verbose:
-                                print "Found calendar data: %s" % (fpath,)
+                                print("Found calendar data: %s" % (fpath,))
                             paths.append(fpath)
                 else:
                     for skip in skips:
@@ -49,12 +51,12 @@ def loadCalendarFromZoneinfo(zoneinfopath, skips=(), only=(), verbose=False, qui
                             break
                     else:
                         if verbose:
-                            print "Found calendar data: %s" % (fpath,)
+                            print("Found calendar data: %s" % (fpath,))
                         paths.append(fpath)
     scanForICS(zoneinfopath)
 
     if not quiet:
-        print "Parsing calendar data in: %s" % (zoneinfopath,)
+        print("Parsing calendar data in: %s" % (zoneinfopath,))
     return loadCalendar(paths, verbose)
 
 
@@ -63,12 +65,12 @@ def loadCalendar(files, verbose):
     cal = Calendar()
     for file in files:
         if verbose:
-            print "Parsing calendar data: %s" % (file,)
+            print("Parsing calendar data: %s" % (file,))
         with open(file, "r") as fin:
             try:
                 cal.parse(fin)
-            except InvalidData, e:
-                print "Failed to parse bad data: %s" % (e.mData,)
+            except InvalidData as e:
+                print("Failed to parse bad data: %s" % (e.mData,))
                 raise
     return CalendarZonesWrapper(calendar=cal)
 
@@ -78,7 +80,7 @@ def parseTZData(zonedir, zonefiles):
     for file in zonefiles:
         zonefile = os.path.join(zonedir, file)
         if not os.path.exists(zonefile):
-            print "Zone file '%s' does not exist." % (zonefile,)
+            print("Zone file '%s' does not exist." % (zonefile,))
         parser.parse(zonefile)
     return CalendarZonesWrapper(zones=parser)
 
@@ -112,19 +114,19 @@ def compareCalendars(calendar1, calendar2, start, end, filterTzids=(), verbose=F
     # Find TZIDs that do not have a corresponding zone
     missing = tzids1.difference(tzids2)
     if missing:
-        print """TZIDs in calendar 1 not in calendar 2 files: %s
-These cannot be checked.""" % (", ".join(sorted(missing)),)
+        print("""TZIDs in calendar 1 not in calendar 2 files: %s
+These cannot be checked.""" % (", ".join(sorted(missing)),))
 
     for tzid in sorted(tzids1.intersection(tzids2)):
         if filterTzids and tzid not in filterTzids:
             continue
         if not quiet:
-            print "\nChecking TZID: %s" % (tzid,)
+            print("\nChecking TZID: %s" % (tzid,))
         calendardates1 = calendar1.expandTransitions(tzid, start, end)
         calendardates2 = calendar2.expandTransitions(tzid, start, end)
         if verbose:
-            print "Calendar 1 dates: %s" % (formattedExpandedDates(calendardates1),)
-            print "Calendar 2 dates: %s" % (formattedExpandedDates(calendardates2),)
+            print("Calendar 1 dates: %s" % (formattedExpandedDates(calendardates1),))
+            print("Calendar 2 dates: %s" % (formattedExpandedDates(calendardates2),))
         set1 = set(calendardates1)
         set2 = set(calendardates2)
         d1 = set1.difference(set2)
@@ -139,11 +141,11 @@ These cannot be checked.""" % (", ".join(sorted(missing)),)
             if i[2] == i[3]:
                 d2.discard(i)
         if d1:
-            print "In calendar 1 but not in calendar 2 tzid=%s: %s" % (tzid, formattedExpandedDates(d1),)
+            print("In calendar 1 but not in calendar 2 tzid=%s: %s" % (tzid, formattedExpandedDates(d1),))
         if d2:
-            print "In calendar 2 but not in calendar 1 tzid=%s: %s" % (tzid, formattedExpandedDates(d2),)
+            print("In calendar 2 but not in calendar 1 tzid=%s: %s" % (tzid, formattedExpandedDates(d2),))
         if not d1 and not d2 and not quiet:
-            print "Matched: %s" % (tzid,)
+            print("Matched: %s" % (tzid,))
 
 
 def getTZIDs(cal):
@@ -189,9 +191,9 @@ def secondsToTime(seconds):
 
 def usage(error_msg=None):
     if error_msg:
-        print error_msg
+        print(error_msg)
 
-    print """Usage: tzverify [options] DIR1 DIR2
+    print("""Usage: tzverify [options] DIR1 DIR2
 Options:
     -h            Print this help and exit
     -v            Be verbose
@@ -207,7 +209,7 @@ Description:
     This utility will compare iCalendar zoneinfo hierarchies by expanding
     timezone transitions and comparing.
 
-"""
+""")
 
     if error_msg:
         raise ValueError(error_msg)

--- a/src/zonal/zone.py
+++ b/src/zonal/zone.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 #    Copyright (c) 2007-2013 Cyrus Daboo. All rights reserved.
 #
@@ -20,8 +21,13 @@ from pycalendar.icalendar.property import Property
 from pycalendar.icalendar.vtimezone import VTimezone
 from pycalendar.icalendar.vtimezonestandard import Standard
 from pycalendar.utcoffsetvalue import UTCOffsetValue
-import rule
-import utils
+from . import rule
+from . import utils
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 """
 Class that maintains a TZ data Zone.


### PR DESCRIPTION
Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run __futurize --stage1__ http://python-future.org/futurize_cheatsheet.html

Python 3 syntax compatibility does __not__ mean that the port is complete.  More work may be require to complete the port to Python 3.  #1

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
